### PR TITLE
🔀 :: (#34) Base Scaffold, Base Appbar 퍼블리싱

### DIFF
--- a/lib/core/config/widget/base_appbar.dart
+++ b/lib/core/config/widget/base_appbar.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:jusicool_design_system/jusicool_design_system.dart';
+
+class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
+  const BaseAppbar({
+    super.key,
+    this.title = '',
+    this.centerTitle = true,
+    this.textStyle,
+    this.backgroundColor,
+    this.actionWidgets,
+    this.backButton = false,
+  });
+
+  final String title;
+  final bool centerTitle;
+  final TextStyle? textStyle;
+  final Color? backgroundColor;
+  final bool backButton;
+  final List<Widget>? actionWidgets;
+  final double elevation = 0.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: Text(title),
+      centerTitle: centerTitle,
+      backgroundColor: backgroundColor ?? JusicoolColor.white,
+      elevation: elevation,
+      scrolledUnderElevation: 0.0,
+      titleTextStyle: textStyle ?? JusicoolTypography.subTitle,
+      leading: IconButton(
+        onPressed: () {
+          Navigator.of(context).pop();
+        },
+        icon: JusicoolIcon.backArrow(
+          width: 24.w,
+          height: 24.h,
+          color: JusicoolColor.black,
+        ),
+      ),
+      actionsPadding: EdgeInsets.only(right: 24),
+      actions: actionWidgets ?? [],
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(57.h);
+}

--- a/lib/core/config/widget/base_appbar.dart
+++ b/lib/core/config/widget/base_appbar.dart
@@ -30,16 +30,19 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       elevation: elevation,
       scrolledUnderElevation: 0.0,
       titleTextStyle: textStyle ?? JusicoolTypography.subTitle,
-      leading: IconButton(
-        onPressed: () {
-          Navigator.of(context).pop();
-        },
-        icon: JusicoolIcon.backArrow(
-          width: 24.w,
-          height: 24.h,
-          color: JusicoolColor.black,
-        ),
-      ),
+      leading:
+          backButton
+              ? IconButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                icon: JusicoolIcon.backArrow(
+                  width: 24.w,
+                  height: 24.h,
+                  color: JusicoolColor.black,
+                ),
+              )
+              : null,
       actionsPadding: EdgeInsets.only(right: 24),
       actions: actionWidgets ?? [],
     );

--- a/lib/core/config/widget/base_scaffold.dart
+++ b/lib/core/config/widget/base_scaffold.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+abstract class BaseScaffold extends ConsumerWidget {
+  const BaseScaffold({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: backgroundColor,
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+      appBar: buildAppBar(context, ref),
+      body:
+          useSafeArea
+              ? SafeArea(
+                top: setTopSafeArea,
+                bottom: setBottomSafeArea,
+                child: buildBody(context, ref),
+              )
+              : buildBody(context, ref),
+      bottomNavigationBar: buildBottomNavigationBar(context, ref),
+    );
+  }
+
+  @protected
+  Color get backgroundColor => Colors.white;
+
+  @protected
+  bool get resizeToAvoidBottomInset => true;
+
+  @protected
+  bool get useSafeArea => true;
+
+  @protected
+  bool get setBottomSafeArea => true;
+
+  @protected
+  bool get setTopSafeArea => true;
+
+  @protected
+  PreferredSizeWidget? buildAppBar(BuildContext context, WidgetRef ref) => null;
+
+  @protected
+  Widget buildBody(BuildContext context, WidgetRef ref);
+
+  @protected
+  Widget? buildBottomNavigationBar(BuildContext context, WidgetRef ref) => null;
+}


### PR DESCRIPTION
## 💡 개요

- Base Scaffold를 퍼블리싱 했습니다
- Base Appbar를 퍼블리싱 했습니다 

## 📃 작업내용

- 전역적으로 사용할 수 있는 Base Scaffold를 퍼블리싱하여 코드의 가독성을 높혔습니다.
- 전역적으로 사용할 수 있는 Base Appbar를 퍼블리싱하여 코드의 가독성을 높혔습니다.

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

```dart
import '../../../core/config/widget/base_appbar.dart';
import '../../../core/config/widget/base_scaffold.dart';

class CandlestickChartScaffold extends BaseScaffold {
  const CandlestickChartScaffold({
    super.key,
    required this.candlestickChartWidget,
    required this.stocksInfoTabBar,
    required this.stocksInfoTabBarView,
  });

  final Widget candlestickChartWidget;
  final Widget stocksInfoTabBar;
  final Widget stocksInfoTabBarView;

  @override
  Widget buildBody(BuildContext context, WidgetRef ref) {
    return SingleChildScrollView(
      child: Padding(
        padding: EdgeInsets.symmetric(vertical: 16.h),
        child: Column(
          spacing: 24,
          children: [
            candlestickChartWidget,
            stocksInfoTabBar,
            stocksInfoTabBarView,
          ],
        ),
      ),
    );
  }

  @override
  PreferredSizeWidget? buildAppBar(BuildContext context, WidgetRef ref) {
    return BaseAppbar(
      title: '마이크로소프트',
      backButton: true,
      actionWidgets: [
        IconButton(
          onPressed: () {},
          icon: JusicoolIcon.setting(
            width: 24.w,
            height: 24.h,
            color: JusicoolColor.black,
          ),
        ),
      ],
    );
  }
}

```

## 🎸 기타